### PR TITLE
SimpleDataset: include non-model queryset fields

### DIFF
--- a/django_tablib/datasets.py
+++ b/django_tablib/datasets.py
@@ -8,9 +8,16 @@ class SimpleDataset(BaseDataset):
         self.queryset = queryset
         self.encoding = encoding
         if headers is None:
-            fields = queryset.model._meta.fields
-            self.header_list = [field.name for field in fields]
-            self.attr_list = self.header_list
+            # We'll set the queryset to include all fields including calculated
+            # aggregates using the same names as a values() queryset:
+            v_qs = queryset.values()
+            headers = []
+            headers.extend(v_qs.query.extra_select)
+            headers.extend(v_qs.field_names)
+            headers.extend(v_qs.query.aggregate_select)
+
+            self.header_list = headers
+            self.attr_list = headers
         elif isinstance(headers, dict):
             self.header_dict = headers
             self.header_list = self.header_dict.keys()


### PR DESCRIPTION
This changes SimpleDataset to use the same list of field names as a 
ValuesQuerySet would include, which will include calculated fields added using
aggregates or `select_extra`
