### PR TITLE
SimpleDataset: include non-model queryset fields

### DIFF
--- a/django_tablib/base.py
+++ b/django_tablib/base.py
@@ -16,8 +16,6 @@ mimetype_map = {
 
 class BaseDataset(tablib.Dataset):
 
-    encoding = 'utf-8'
-
     def __init__(self):
         data = map(self._getattrs, self.queryset)
         super(BaseDataset, self).__init__(headers=self.header_list, *data)
@@ -25,19 +23,15 @@ class BaseDataset(tablib.Dataset):
     def _cleanval(self, value, attr):
         if callable(value):
             value = value()
-        elif value is None or unicode(value) == u"None":
+        elif value is None or tablib.compat.unicode(value) == u"None":
             value = ""
 
-        t = type(value)
-        if t is str:
-            return value
-        elif t is bool:
+        if isinstance(value, bool):
             value = _("Y") if value else _("N")
-            return smart_unicode(value).encode(self.encoding)
-        elif t in [datetime.date, datetime.datetime]:
-            return date(value, 'SHORT_DATE_FORMAT').encode(self.encoding)
+        elif isinstance(value, (datetime.date, datetime.datetime)):
+            value = date(value, 'SHORT_DATE_FORMAT')
 
-        return smart_unicode(value).encode(self.encoding)
+        return smart_unicode(value)
 
     def _getattrs(self, obj):
         attrs = []


### PR DESCRIPTION
This changes SimpleDataset to use the same list of field names as a 
ValuesQuerySet would include, which will include calculated fields added using
aggregates or `select_extra`
